### PR TITLE
TS-1790 Updated C# examples with signing token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 obj/
 bin/
 .idea/
+/csharp/dotnet.sln.DotSettings.user

--- a/csharp/Readme.md
+++ b/csharp/Readme.md
@@ -85,9 +85,17 @@ dotnet run
 * **Nonce**: A one-time token-based authentication.
 * **Timestamp**: A time-based token authentication.
 - Examples of both methods are provided in the `Program.cs` file.
+
+**Authentication Flow**:
+1. The initial authorization request uses the user's password to sign the request.
+2. The authorization response returns both an API token (`Token`) and a signing token (`SigningToken`).
+3. All subsequent API requests use the `SigningToken` (not the password) to generate the `X-YB-Sign` header.
+
   Authenticate using Nonce:
     ```csharp
     var authNonceResponse = await Authorise(login, AuthenticationMethod.Nonce);
+    user.ApiKey = authNonceResponse.Token;
+    user.SigningToken = authNonceResponse.SigningToken;
     ```
 
 ### Querying Symbols
@@ -178,7 +186,8 @@ var listenTask = Task.Run(async () => await WebSockerHelpers.ListenWebSocket(soc
 
 ## Notes
 
-- Ensure that the API key and credentials are kept secure and not hardcoded in production environments.
+- Ensure that the API key, signing token, and credentials are kept secure and not hardcoded in production environments.
+- The signing token (`SigningToken`) is used to sign all API requests after the initial authorization. This separates the user's password from the ongoing API communication.
 - Handle WebSocket errors and disconnections gracefully in real-world applications.
 - Trade Server API port starts with 2, Web Socket port starts with 3.
 

--- a/csharp/Readme.md
+++ b/csharp/Readme.md
@@ -36,13 +36,19 @@ This project demonstrates how to interact with a trading server using both HTTP 
 
 ## Project Structure
 
-- **`WebSockerHelpers.cs`**:
+- **`ApiHeaders.cs`**:
+    - Contains methods for generating HTTP headers for authentication and API requests.
+    - `GetAuthorizationHeaders()` - generates headers for authorization (uses password).
+    - `GetApiGetHeaders()` and `GetApiPostHeaders()` - generate headers for API calls (use signingToken).
+- **`AuthUser.cs`**:
+    - Represents an authenticated session containing ApiKey and SigningToken (no password).
+- **`WebSocketHelpers.cs`**:
     - Contains helper methods for sending and receiving WebSocket messages.
 - **`Program.cs`**:
     - The main entry point of the application, demonstrating API and WebSocket usage.
 - **`AuthenticationMethod.cs`**:
     - Defines the `AuthenticationMethod` enum for specifying authentication types.
-- **`Readme.md`**:
+- **`README.md`**:
     - Documentation for the project.
 
 ## Setup and Configuration
@@ -87,15 +93,22 @@ dotnet run
 - Examples of both methods are provided in the `Program.cs` file.
 
 **Authentication Flow**:
-1. The initial authorization request uses the user's password to sign the request.
-2. The authorization response returns both an API token (`Token`) and a signing token (`SigningToken`).
-3. All subsequent API requests use the `SigningToken` (not the password) to generate the `X-YB-Sign` header.
+1. Call `Authorise()` with login, password, and authentication method.
+2. The authorization uses `ApiHeaders.GetAuthorizationHeaders()` which signs the request with the password.
+3. The server responds with an `ApiToken` containing both `Token` (API key) and `SigningToken`.
+4. Create an `AuthUser` object with these tokens - **the password is never stored in the session**.
+5. All subsequent API calls use `ApiHeaders.GetApiPostHeaders()` or `GetApiGetHeaders()` which automatically sign requests using the `SigningToken` from the session.
 
-  Authenticate using Nonce:
+This architecture makes it **impossible** to accidentally use the password after authorization.
+
+  Authenticate and create a session:
     ```csharp
-    var authNonceResponse = await Authorise(login, AuthenticationMethod.Nonce);
-    user.ApiKey = authNonceResponse.Token;
-    user.SigningToken = authNonceResponse.SigningToken;
+    var user = await Authorise(login, password, AuthenticationMethod.Nonce);
+    // user contains only ApiKey and SigningToken - no password
+    
+    // All API calls now use the user
+    await AddSymbol(user, symbol, AuthenticationMethod.Nonce);
+    await QuerySymbols(user, AuthenticationMethod.Nonce);
     ```
 
 ### Querying Symbols
@@ -103,7 +116,7 @@ dotnet run
 - The response is logged to the console.
 - Example:
   ```csharp
-  await QuerySymbols(authNonceResponse.Token, AuthenticationMethod.Nonce);
+  await QuerySymbols(user, AuthenticationMethod.Nonce);
   ```
   
 ### WebSocket Communication
@@ -161,12 +174,12 @@ dotnet run
 
 Sending WebSocket messages:
 ```csharp
-await WebSockerHelpers.SendAsync(socket, pingMessageJson);
+await WebSocketHelpers.SendAsync(socket, pingMessageJson);
 ```
   
 Receiving WebSocket messages:
 ```csharp
-var listenTask = Task.Run(async () => await WebSockerHelpers.ListenWebSocket(socket, CancellationToken.None));
+var listenTask = Task.Run(async () => await WebSocketHelpers.ListenWebSocket(socket, CancellationToken.None));
 ```
 
 ## Requirements
@@ -186,8 +199,11 @@ var listenTask = Task.Run(async () => await WebSockerHelpers.ListenWebSocket(soc
 
 ## Notes
 
-- Ensure that the API key, signing token, and credentials are kept secure and not hardcoded in production environments.
-- The signing token (`SigningToken`) is used to sign all API requests after the initial authorization. This separates the user's password from the ongoing API communication.
+- Ensure that credentials are kept secure and not hardcoded in production environments.
+- **Architecture design**: The `AuthUser` class contains only API credentials (ApiKey and SigningToken), never the password. This separation ensures the password is used exclusively for authorization.
+- Authorization requests use `GetAuthorizationHeaders(password, ...)` which signs with the password.
+- All API requests use `GetApiPostHeaders(user, ...)` or `GetApiGetHeaders(user)` which sign with the signingToken.
+- This type-safe design makes it impossible to accidentally use the password for API calls.
 - Handle WebSocket errors and disconnections gracefully in real-world applications.
 - Trade Server API port starts with 2, Web Socket port starts with 3.
 

--- a/csharp/api-example/ApiHeaders.cs
+++ b/csharp/api-example/ApiHeaders.cs
@@ -26,24 +26,26 @@ public static class ApiHeaders
     private static Dictionary<string, string> GetPostHeadersWithNonce<T>(AuthUser user, T data)
     {
         var nonce = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var secret = user?.SigningToken ?? user?.Password ?? string.Empty;
 
         return new Dictionary<string, string>
         {
             { "X-YB-Nonce", nonce.ToString() },
             { "X-YB-API-Key", user?.ApiKey ?? string.Empty },
-            { "X-YB-Sign", GetHmacDigest(user?.Password ?? string.Empty, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nNonce={nonce}") }
+            { "X-YB-Sign", GetHmacDigest(secret, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nNonce={nonce}") }
         };
     }
 
     private static Dictionary<string, string> GetPostHeadersWithTimestamp<T>(AuthUser user, T data)
     {
         var timestampInMicroseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000;
+        var secret = user?.SigningToken ?? user?.Password ?? string.Empty;
 
         return new Dictionary<string, string>
         {
             { "X-YB-Timestamp", timestampInMicroseconds.ToString() },
             { "X-YB-API-Key", user?.ApiKey ?? string.Empty },
-            { "X-YB-Sign", GetHmacDigest(user?.Password ?? string.Empty, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nTimestamp={timestampInMicroseconds}") }
+            { "X-YB-Sign", GetHmacDigest(secret, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nTimestamp={timestampInMicroseconds}") }
         };
     }
 

--- a/csharp/api-example/ApiHeaders.cs
+++ b/csharp/api-example/ApiHeaders.cs
@@ -8,44 +8,80 @@ public static class ApiHeaders
 {
     public static readonly JsonSerializerOptions JsonSerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
     
-    public static Dictionary<string, string> GetGetHeaders(AuthUser user)
+    /// <summary>
+    /// Get headers for authorization request. Uses password for signing.
+    /// </summary>
+    public static Dictionary<string, string> GetAuthorizationHeaders<T>(string password, T data, AuthenticationMethod authenticationMethod = AuthenticationMethod.Nonce)
+    {
+        return authenticationMethod == AuthenticationMethod.Timestamp
+            ? GetAuthHeadersWithTimestamp(password, data)
+            : GetAuthHeadersWithNonce(password, data);
+    }
+    
+    /// <summary>
+    /// Get headers for GET requests (requires active session).
+    /// </summary>
+    public static Dictionary<string, string> GetApiGetHeaders(AuthUser authUser)
     {
         return new Dictionary<string, string>
         {
-            { "X-YB-API-Key", user?.ApiKey ?? string.Empty }
+            { "X-YB-API-Key", authUser.ApiKey }
         };
     }
 
-    public static Dictionary<string, string> GetPostHeaders<T>(AuthUser user, T data, AuthenticationMethod authenticationMethod = AuthenticationMethod.Nonce)
+    /// <summary>
+    /// Get headers for POST requests (requires active session). Uses signingToken for signing.
+    /// </summary>
+    public static Dictionary<string, string> GetApiPostHeaders<T>(AuthUser authUser, T data, AuthenticationMethod authenticationMethod = AuthenticationMethod.Nonce)
     {
         return authenticationMethod == AuthenticationMethod.Timestamp
-            ? GetPostHeadersWithTimestamp(user, data)
-            : GetPostHeadersWithNonce(user, data);
+            ? GetApiHeadersWithTimestamp(authUser, data)
+            : GetApiHeadersWithNonce(authUser, data);
     }
 
-    private static Dictionary<string, string> GetPostHeadersWithNonce<T>(AuthUser user, T data)
+    private static Dictionary<string, string> GetAuthHeadersWithNonce<T>(string password, T data)
     {
         var nonce = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        var secret = user?.SigningToken ?? user?.Password ?? string.Empty;
 
         return new Dictionary<string, string>
         {
             { "X-YB-Nonce", nonce.ToString() },
-            { "X-YB-API-Key", user?.ApiKey ?? string.Empty },
-            { "X-YB-Sign", GetHmacDigest(secret, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nNonce={nonce}") }
+            { "X-YB-Sign", GetHmacDigest(password, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nNonce={nonce}") }
         };
     }
 
-    private static Dictionary<string, string> GetPostHeadersWithTimestamp<T>(AuthUser user, T data)
+    private static Dictionary<string, string> GetAuthHeadersWithTimestamp<T>(string password, T data)
     {
         var timestampInMicroseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000;
-        var secret = user?.SigningToken ?? user?.Password ?? string.Empty;
 
         return new Dictionary<string, string>
         {
             { "X-YB-Timestamp", timestampInMicroseconds.ToString() },
-            { "X-YB-API-Key", user?.ApiKey ?? string.Empty },
-            { "X-YB-Sign", GetHmacDigest(secret, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nTimestamp={timestampInMicroseconds}") }
+            { "X-YB-Sign", GetHmacDigest(password, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nTimestamp={timestampInMicroseconds}") }
+        };
+    }
+
+    private static Dictionary<string, string> GetApiHeadersWithNonce<T>(AuthUser authUser, T data)
+    {
+        var nonce = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        return new Dictionary<string, string>
+        {
+            { "X-YB-Nonce", nonce.ToString() },
+            { "X-YB-API-Key", authUser.ApiKey },
+            { "X-YB-Sign", GetHmacDigest(authUser.SigningToken, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nNonce={nonce}") }
+        };
+    }
+
+    private static Dictionary<string, string> GetApiHeadersWithTimestamp<T>(AuthUser authUser, T data)
+    {
+        var timestampInMicroseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000;
+
+        return new Dictionary<string, string>
+        {
+            { "X-YB-Timestamp", timestampInMicroseconds.ToString() },
+            { "X-YB-API-Key", authUser.ApiKey },
+            { "X-YB-Sign", GetHmacDigest(authUser.SigningToken, $"Content={JsonSerializer.Serialize(data, JsonSerializerOptions)}\nTimestamp={timestampInMicroseconds}") }
         };
     }
 

--- a/csharp/api-example/ApiToken.cs
+++ b/csharp/api-example/ApiToken.cs
@@ -3,5 +3,6 @@
 public class ApiToken
 {
     public string Token { get; set; } = null!;
+    public string SigningToken { get; set; } = null!;
     public long Expiration { get; set; }
 }

--- a/csharp/api-example/AuthUser.cs
+++ b/csharp/api-example/AuthUser.cs
@@ -1,8 +1,11 @@
-﻿namespace ApiExample;
+namespace ApiExample;
 
+/// <summary>
+/// Represents an authenticated user session with API credentials.
+/// Contains only the tokens needed for API calls (no password).
+/// </summary>
 public class AuthUser
 {
-    public string? ApiKey { get; set; }
-    public string? Password { get; set; }
-    public string? SigningToken { get; set; }
+    public string ApiKey { get; set; } = null!;
+    public string SigningToken { get; set; } = null!;
 }

--- a/csharp/api-example/AuthUser.cs
+++ b/csharp/api-example/AuthUser.cs
@@ -4,4 +4,5 @@ public class AuthUser
 {
     public string? ApiKey { get; set; }
     public string? Password { get; set; }
+    public string? SigningToken { get; set; }
 }

--- a/csharp/api-example/Program.cs
+++ b/csharp/api-example/Program.cs
@@ -15,6 +15,7 @@ Console.WriteLine("================================== Authorization (Nonce) ====
 // Api examples (Nonce)
 var authNonceResponse = await Authorise(login, AuthenticationMethod.Nonce);
 user.ApiKey = authNonceResponse!.Token;
+user.SigningToken = authNonceResponse.SigningToken;
 
 Console.WriteLine("================================== Add Symbol (Nonce) ==================================");
 await AddSymbol(symbol1, AuthenticationMethod.Nonce);
@@ -22,11 +23,13 @@ await AddSymbol(symbol1, AuthenticationMethod.Nonce);
 Console.WriteLine("================================== Get Symbols (Nonce) ==================================");
 await QuerySymbols(AuthenticationMethod.Nonce);
 user.ApiKey = "";
+user.SigningToken = null;
 
 Console.WriteLine("================================== Authorization (Timestamp) ==================================");
 // Api examples (Timestamp)
 var authTimestampResponse = await Authorise(login, AuthenticationMethod.Timestamp);
 user.ApiKey = authTimestampResponse!.Token;
+user.SigningToken = authTimestampResponse.SigningToken;
 
 Console.WriteLine("================================== Add Symbol (Timestamp) ==================================");
 var symbol2 = GetSymbol();


### PR DESCRIPTION
## Description

This PR updates the C# examples to use `signingToken` for API request signing, matching the pattern used in the Postman examples. The implementation now properly separates authentication (which uses password) from API calls (which use signingToken).

## Changes Made

### Architecture Improvements

1. **Changed `AuthUser` class** - Clean session object containing only `ApiKey` and `SigningToken` (no password stored)

2. **Refactored `ApiHeaders` class** with distinct methods:
   - `GetAuthorizationHeaders(password, ...)` - For authorization endpoint only, signs with password
   - `GetApiPostHeaders(authUser, ...)` - For API POST requests, signs with signingToken
   - `GetApiGetHeaders(authUser)` - For API GET requests

3. **Updated `ApiToken` response model** - Added `SigningToken` property

4. **Refactored `Program.cs`** - Simplified authentication flow:
   - `Authorise()` now returns `AuthUser` object
   - Password is passed as parameter and never stored in session
   - All API methods accept `AuthUser` parameter

### Key Benefits

✅ **Type-safe design** - Impossible to accidentally use password for API calls  
✅ **Clear separation of concerns** - Authorization vs API operations are explicit  
✅ **Enhanced security** - Password never persists in session objects  
✅ **Matches Postman examples** - Consistent pattern across all sample code  
✅ **Self-documenting** - Method signatures clearly show what credentials are needed
